### PR TITLE
CC-33579 - introduce connector level proxy configs and make HttpClient keyed on proxy [re-raise]

### DIFF
--- a/e2e-jar-test/pom.xml
+++ b/e2e-jar-test/pom.xml
@@ -27,7 +27,7 @@
             <dependency>
                 <groupId>net.snowflake</groupId>
                 <artifactId>snowflake-ingest-sdk</artifactId>
-                <version>2.1.4</version>
+                <version>2.1.5</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <!-- Arifact name and version information -->
   <groupId>io.confluent</groupId>
   <artifactId>snowflake-ingest-sdk</artifactId>
-  <version>2.1.4</version>
+  <version>2.1.5</version>
   <packaging>jar</packaging>
   <name>Snowflake Ingest SDK</name>
   <description>Snowflake Ingest SDK</description>

--- a/src/main/java/net/snowflake/ingest/SimpleIngestManager.java
+++ b/src/main/java/net/snowflake/ingest/SimpleIngestManager.java
@@ -386,29 +386,26 @@ public class SimpleIngestManager implements AutoCloseable {
         new RequestBuilder(account, user, keyPair, schemeName, hostName, port, userAgentSuffix);
   }
 
-
   /* Another flavor of constructor which supports userAgentSuffix and proxyProperties */
   public SimpleIngestManager(
-    String account,
-    String user,
-    String pipe,
-    PrivateKey privateKey,
-    String schemeName,
-    String hostName,
-    int port,
-    String userAgentSuffix,
-    Properties proxyProperties)
-    throws NoSuchAlgorithmException, InvalidKeySpecException {
-  KeyPair keyPair = Utils.createKeyPairFromPrivateKey(privateKey);
-  // call our initializer method
-  init(account, user, pipe, keyPair, proxyProperties);
+      String account,
+      String user,
+      String pipe,
+      PrivateKey privateKey,
+      String schemeName,
+      String hostName,
+      int port,
+      String userAgentSuffix,
+      Properties proxyProperties)
+      throws NoSuchAlgorithmException, InvalidKeySpecException {
+    KeyPair keyPair = Utils.createKeyPairFromPrivateKey(privateKey);
+    // call our initializer method
+    init(account, user, pipe, keyPair, proxyProperties);
 
-  // make the request builder we'll use to build messages to the service
-  builder =
-      new RequestBuilder(account, user, keyPair, schemeName, hostName, port, userAgentSuffix);
-}
-
-  
+    // make the request builder we'll use to build messages to the service
+    builder =
+        new RequestBuilder(account, user, keyPair, schemeName, hostName, port, userAgentSuffix);
+  }
 
   // ========= Constructors End =========
 
@@ -435,7 +432,8 @@ public class SimpleIngestManager implements AutoCloseable {
    * @param keyPair the KeyPair we'll use to sign JWT tokens
    * @param proxyProperties proxy properties for HTTP client configuration
    */
-  private void init(String account, String user, String pipe, KeyPair keyPair, Properties proxyProperties) {
+  private void init(
+      String account, String user, String pipe, KeyPair keyPair, Properties proxyProperties) {
     // set up our reference variables
     this.account = account;
     this.user = user;
@@ -444,11 +442,19 @@ public class SimpleIngestManager implements AutoCloseable {
 
     // make our client for sending requests with proxy properties support
     if (proxyProperties != null && !proxyProperties.isEmpty()) {
-      LOGGER.debug("Creating HTTP client for SimpleIngestManager with proxy properties for account: {}, user: {}", account, user);
+      LOGGER.debug(
+          "Creating HTTP client for SimpleIngestManager with proxy properties for account: {},"
+              + " user: {}",
+          account,
+          user);
     } else {
-      LOGGER.debug("Creating HTTP client for SimpleIngestManager without proxy properties for account: {}, user: {}", account, user);
+      LOGGER.debug(
+          "Creating HTTP client for SimpleIngestManager without proxy properties for account: {},"
+              + " user: {}",
+          account,
+          user);
     }
-    
+
     httpClient = HttpUtil.getHttpClient(account, proxyProperties);
     // make the request builder we'll use to build messages to the service
   }

--- a/src/main/java/net/snowflake/ingest/SimpleIngestManager.java
+++ b/src/main/java/net/snowflake/ingest/SimpleIngestManager.java
@@ -15,6 +15,7 @@ import java.security.PrivateKey;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -385,6 +386,30 @@ public class SimpleIngestManager implements AutoCloseable {
         new RequestBuilder(account, user, keyPair, schemeName, hostName, port, userAgentSuffix);
   }
 
+
+  /* Another flavor of constructor which supports userAgentSuffix and proxyProperties */
+  public SimpleIngestManager(
+    String account,
+    String user,
+    String pipe,
+    PrivateKey privateKey,
+    String schemeName,
+    String hostName,
+    int port,
+    String userAgentSuffix,
+    Properties proxyProperties)
+    throws NoSuchAlgorithmException, InvalidKeySpecException {
+  KeyPair keyPair = Utils.createKeyPairFromPrivateKey(privateKey);
+  // call our initializer method
+  init(account, user, pipe, keyPair, proxyProperties);
+
+  // make the request builder we'll use to build messages to the service
+  builder =
+      new RequestBuilder(account, user, keyPair, schemeName, hostName, port, userAgentSuffix);
+}
+
+  
+
   // ========= Constructors End =========
 
   /**
@@ -397,14 +422,34 @@ public class SimpleIngestManager implements AutoCloseable {
    * @param keyPair the KeyPair we'll use to sign JWT tokens
    */
   private void init(String account, String user, String pipe, KeyPair keyPair) {
+    init(account, user, pipe, keyPair, new Properties());
+  }
+
+  /**
+   * init - Does the basic work of constructing a SimpleIngestManager that is common across all
+   * constructors
+   *
+   * @param account The account into which we're loading
+   * @param user the user performing this load
+   * @param pipe the fully qualified name of pipe
+   * @param keyPair the KeyPair we'll use to sign JWT tokens
+   * @param proxyProperties proxy properties for HTTP client configuration
+   */
+  private void init(String account, String user, String pipe, KeyPair keyPair, Properties proxyProperties) {
     // set up our reference variables
     this.account = account;
     this.user = user;
     this.pipe = pipe;
     this.keyPair = keyPair;
 
-    // make our client for sending requests
-    httpClient = HttpUtil.getHttpClient(account);
+    // make our client for sending requests with proxy properties support
+    if (proxyProperties != null && !proxyProperties.isEmpty()) {
+      LOGGER.info("Creating HTTP client for SimpleIngestManager with proxy properties for account: {}, user: {}", account, user);
+    } else {
+      LOGGER.info("Creating HTTP client for SimpleIngestManager without proxy properties for account: {}, user: {}", account, user);
+    }
+    
+    httpClient = HttpUtil.getHttpClient(account, proxyProperties);
     // make the request builder we'll use to build messages to the service
   }
 

--- a/src/main/java/net/snowflake/ingest/SimpleIngestManager.java
+++ b/src/main/java/net/snowflake/ingest/SimpleIngestManager.java
@@ -444,9 +444,9 @@ public class SimpleIngestManager implements AutoCloseable {
 
     // make our client for sending requests with proxy properties support
     if (proxyProperties != null && !proxyProperties.isEmpty()) {
-      LOGGER.info("Creating HTTP client for SimpleIngestManager with proxy properties for account: {}, user: {}", account, user);
+      LOGGER.debug("Creating HTTP client for SimpleIngestManager with proxy properties for account: {}, user: {}", account, user);
     } else {
-      LOGGER.info("Creating HTTP client for SimpleIngestManager without proxy properties for account: {}, user: {}", account, user);
+      LOGGER.debug("Creating HTTP client for SimpleIngestManager without proxy properties for account: {}, user: {}", account, user);
     }
     
     httpClient = HttpUtil.getHttpClient(account, proxyProperties);

--- a/src/main/java/net/snowflake/ingest/connection/RequestBuilder.java
+++ b/src/main/java/net/snowflake/ingest/connection/RequestBuilder.java
@@ -110,7 +110,7 @@ public class RequestBuilder {
   // Don't change!
   public static final String CLIENT_NAME = "SnowpipeJavaSDK";
 
-  public static final String DEFAULT_VERSION = "2.1.4";
+  public static final String DEFAULT_VERSION = "2.1.5";
 
   public static final String JAVA_USER_AGENT = "JAVA";
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -167,7 +167,8 @@ class FlushService<T> {
               client.getHttpClient(),
               client.getRequestBuilder(),
               client.getName(),
-              DEFAULT_MAX_UPLOAD_RETRIES);
+              DEFAULT_MAX_UPLOAD_RETRIES,
+              client.getProxyProperties());
     } catch (SnowflakeSQLException | IOException err) {
       throw new SFException(err, ErrorCode.UNABLE_TO_CONNECT_TO_STAGE);
     }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -142,6 +142,9 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
   // Background thread that uploads telemetry data periodically
   private ScheduledExecutorService telemetryWorker;
 
+  // Store original properties for proxy configuration
+  private final Properties originalProperties;
+
   /**
    * Constructor
    *
@@ -162,11 +165,33 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
       RequestBuilder requestBuilder,
       Map<String, Object> parameterOverrides) {
     this.parameterProvider = new ParameterProvider(parameterOverrides, prop);
+    this.originalProperties = prop;
 
     this.name = name;
     String accountName = accountURL == null ? null : accountURL.getAccount();
     this.isTestMode = isTestMode;
-    this.httpClient = httpClient == null ? HttpUtil.getHttpClient(accountName) : httpClient;
+    
+    if (prop != null && !prop.isEmpty()) {
+      // Check if proxy-related properties are present
+      boolean hasProxyConfig = prop.stringPropertyNames().stream()
+          .anyMatch(key -> key.startsWith("http.proxy") || 
+                          key.equals("useProxy") || 
+                          key.equals("proxyHost") || 
+                          key.equals("proxyPort") ||
+                          key.equals("nonProxyHosts") ||
+                          key.equals("proxyUser") ||
+                          key.equals("proxyPassword"));
+      
+      if (hasProxyConfig) {
+        logger.logInfo("Creating HTTP client for SnowflakeStreamingIngestClient with proxy configuration for account: {}, client: {}", accountName, name);
+      } else {
+        logger.logInfo("Creating HTTP client for SnowflakeStreamingIngestClient without proxy configuration for account: {}, client: {}", accountName, name);
+      }
+    } else {
+      logger.logInfo("Creating HTTP client for SnowflakeStreamingIngestClient with no properties for account: {}, client: {}", accountName, name);
+    }
+    
+    this.httpClient = (httpClient != null) ? httpClient : HttpUtil.getHttpClient(accountName, prop);
     this.channelCache = new ChannelCache<>();
     this.isClosed = false;
     this.requestBuilder = requestBuilder;
@@ -1074,5 +1099,49 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
     if (!this.isTestMode) {
       HttpUtil.shutdownHttpConnectionManagerDaemonThread();
     }
+  }
+
+  /**
+   * Extract proxy properties from the original Properties object
+   *
+   * @return Properties containing proxy configuration
+   */
+  Properties getProxyProperties() {
+    Properties proxyProperties = new Properties();
+
+    
+    if (this.originalProperties != null) {
+
+      for (String key : this.originalProperties.stringPropertyNames()) {
+        if (key.equals(SFSessionProperty.USE_PROXY.getPropertyKey()) ||
+            key.equals(SFSessionProperty.PROXY_HOST.getPropertyKey()) ||
+            key.equals(SFSessionProperty.PROXY_PORT.getPropertyKey()) ||
+            key.equals(SFSessionProperty.NON_PROXY_HOSTS.getPropertyKey()) ||
+            key.equals(SFSessionProperty.PROXY_USER.getPropertyKey()) ||
+            key.equals(SFSessionProperty.PROXY_PASSWORD.getPropertyKey())) {
+          proxyProperties.put(key, this.originalProperties.getProperty(key));
+        }
+      }
+      
+      if (!proxyProperties.isEmpty()) {
+        logger.logInfo("Extracted {} proxy properties from original properties for client: {}", proxyProperties.size(), this.name);
+        logger.logDebug("Proxy properties extracted: {}", 
+                       proxyProperties.keySet().stream()
+                           .map(k -> k + "=" + (k.toString().toLowerCase().contains("password") ? "[HIDDEN]" : proxyProperties.get(k)))
+                           .collect(Collectors.joining(", ")));
+      } else {
+        logger.logInfo("No proxy properties found in original properties for client: {}", this.name);
+      }
+    } else {
+      logger.logInfo("Original properties is null, cannot extract proxy properties for client: {}", this.name);
+    }
+    
+    // If no proxy properties found in original properties, fall back to system properties
+    if (proxyProperties.isEmpty()) {
+      logger.logInfo("Falling back to system properties for proxy configuration for client: {}", this.name);
+      return HttpUtil.generateProxyPropertiesForJDBC();
+    }
+    
+    return proxyProperties;
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -183,12 +183,12 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
                           key.equals("proxyPassword"));
       
       if (hasProxyConfig) {
-        logger.logInfo("Creating HTTP client for SnowflakeStreamingIngestClient with proxy configuration for account: {}, client: {}", accountName, name);
+        logger.logDebug("Creating HTTP client for SnowflakeStreamingIngestClient with proxy configuration for account: {}, client: {}", accountName, name);
       } else {
-        logger.logInfo("Creating HTTP client for SnowflakeStreamingIngestClient without proxy configuration for account: {}, client: {}", accountName, name);
+        logger.logDebug("Creating HTTP client for SnowflakeStreamingIngestClient without proxy configuration for account: {}, client: {}", accountName, name);
       }
     } else {
-      logger.logInfo("Creating HTTP client for SnowflakeStreamingIngestClient with no properties for account: {}, client: {}", accountName, name);
+      logger.logDebug("Creating HTTP client for SnowflakeStreamingIngestClient with no properties for account: {}, client: {}", accountName, name);
     }
     
     this.httpClient = (httpClient != null) ? httpClient : HttpUtil.getHttpClient(accountName, prop);
@@ -1124,21 +1124,20 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
       }
       
       if (!proxyProperties.isEmpty()) {
-        logger.logInfo("Extracted {} proxy properties from original properties for client: {}", proxyProperties.size(), this.name);
-        logger.logDebug("Proxy properties extracted: {}", 
+        logger.logTrace("Proxy properties extracted: {}",
                        proxyProperties.keySet().stream()
                            .map(k -> k + "=" + (k.toString().toLowerCase().contains("password") ? "[HIDDEN]" : proxyProperties.get(k)))
                            .collect(Collectors.joining(", ")));
       } else {
-        logger.logInfo("No proxy properties found in original properties for client: {}", this.name);
+        logger.logDebug("No proxy properties found in original properties for client: {}", this.name);
       }
     } else {
-      logger.logInfo("Original properties is null, cannot extract proxy properties for client: {}", this.name);
+      logger.logDebug("Original properties is null, cannot extract proxy properties for client: {}", this.name);
     }
     
     // If no proxy properties found in original properties, fall back to system properties
     if (proxyProperties.isEmpty()) {
-      logger.logInfo("Falling back to system properties for proxy configuration for client: {}", this.name);
+      logger.logDebug("Falling back to system properties for proxy configuration for client: {}", this.name);
       return HttpUtil.generateProxyPropertiesForJDBC();
     }
     

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -170,27 +170,42 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
     this.name = name;
     String accountName = accountURL == null ? null : accountURL.getAccount();
     this.isTestMode = isTestMode;
-    
+
     if (prop != null && !prop.isEmpty()) {
       // Check if proxy-related properties are present
-      boolean hasProxyConfig = prop.stringPropertyNames().stream()
-          .anyMatch(key -> key.startsWith("http.proxy") || 
-                          key.equals("useProxy") || 
-                          key.equals("proxyHost") || 
-                          key.equals("proxyPort") ||
-                          key.equals("nonProxyHosts") ||
-                          key.equals("proxyUser") ||
-                          key.equals("proxyPassword"));
-      
+      boolean hasProxyConfig =
+          prop.stringPropertyNames().stream()
+              .anyMatch(
+                  key ->
+                      key.startsWith("http.proxy")
+                          || key.equals("useProxy")
+                          || key.equals("proxyHost")
+                          || key.equals("proxyPort")
+                          || key.equals("nonProxyHosts")
+                          || key.equals("proxyUser")
+                          || key.equals("proxyPassword"));
+
       if (hasProxyConfig) {
-        logger.logDebug("Creating HTTP client for SnowflakeStreamingIngestClient with proxy configuration for account: {}, client: {}", accountName, name);
+        logger.logDebug(
+            "Creating HTTP client for SnowflakeStreamingIngestClient with proxy configuration for"
+                + " account: {}, client: {}",
+            accountName,
+            name);
       } else {
-        logger.logDebug("Creating HTTP client for SnowflakeStreamingIngestClient without proxy configuration for account: {}, client: {}", accountName, name);
+        logger.logDebug(
+            "Creating HTTP client for SnowflakeStreamingIngestClient without proxy configuration"
+                + " for account: {}, client: {}",
+            accountName,
+            name);
       }
     } else {
-      logger.logDebug("Creating HTTP client for SnowflakeStreamingIngestClient with no properties for account: {}, client: {}", accountName, name);
+      logger.logDebug(
+          "Creating HTTP client for SnowflakeStreamingIngestClient with no properties for account:"
+              + " {}, client: {}",
+          accountName,
+          name);
     }
-    
+
     this.httpClient = (httpClient != null) ? httpClient : HttpUtil.getHttpClient(accountName, prop);
     this.channelCache = new ChannelCache<>();
     this.isClosed = false;
@@ -1109,38 +1124,47 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
   Properties getProxyProperties() {
     Properties proxyProperties = new Properties();
 
-    
     if (this.originalProperties != null) {
 
       for (String key : this.originalProperties.stringPropertyNames()) {
-        if (key.equals(SFSessionProperty.USE_PROXY.getPropertyKey()) ||
-            key.equals(SFSessionProperty.PROXY_HOST.getPropertyKey()) ||
-            key.equals(SFSessionProperty.PROXY_PORT.getPropertyKey()) ||
-            key.equals(SFSessionProperty.NON_PROXY_HOSTS.getPropertyKey()) ||
-            key.equals(SFSessionProperty.PROXY_USER.getPropertyKey()) ||
-            key.equals(SFSessionProperty.PROXY_PASSWORD.getPropertyKey())) {
+        if (key.equals(SFSessionProperty.USE_PROXY.getPropertyKey())
+            || key.equals(SFSessionProperty.PROXY_HOST.getPropertyKey())
+            || key.equals(SFSessionProperty.PROXY_PORT.getPropertyKey())
+            || key.equals(SFSessionProperty.NON_PROXY_HOSTS.getPropertyKey())
+            || key.equals(SFSessionProperty.PROXY_USER.getPropertyKey())
+            || key.equals(SFSessionProperty.PROXY_PASSWORD.getPropertyKey())) {
           proxyProperties.put(key, this.originalProperties.getProperty(key));
         }
       }
-      
+
       if (!proxyProperties.isEmpty()) {
-        logger.logTrace("Proxy properties extracted: {}",
-                       proxyProperties.keySet().stream()
-                           .map(k -> k + "=" + (k.toString().toLowerCase().contains("password") ? "[HIDDEN]" : proxyProperties.get(k)))
-                           .collect(Collectors.joining(", ")));
+        logger.logTrace(
+            "Proxy properties extracted: {}",
+            proxyProperties.keySet().stream()
+                .map(
+                    k ->
+                        k
+                            + "="
+                            + (k.toString().toLowerCase().contains("password")
+                                ? "[HIDDEN]"
+                                : proxyProperties.get(k)))
+                .collect(Collectors.joining(", ")));
       } else {
-        logger.logDebug("No proxy properties found in original properties for client: {}", this.name);
+        logger.logDebug(
+            "No proxy properties found in original properties for client: {}", this.name);
       }
     } else {
-      logger.logDebug("Original properties is null, cannot extract proxy properties for client: {}", this.name);
+      logger.logDebug(
+          "Original properties is null, cannot extract proxy properties for client: {}", this.name);
     }
-    
+
     // If no proxy properties found in original properties, fall back to system properties
     if (proxyProperties.isEmpty()) {
-      logger.logDebug("Falling back to system properties for proxy configuration for client: {}", this.name);
+      logger.logDebug(
+          "Falling back to system properties for proxy configuration for client: {}", this.name);
       return HttpUtil.generateProxyPropertiesForJDBC();
     }
-    
+
     return proxyProperties;
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/StreamingIngestStage.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/StreamingIngestStage.java
@@ -98,11 +98,34 @@ class StreamingIngestStage {
       String clientName,
       int maxUploadRetries)
       throws SnowflakeSQLException, IOException {
+    this(isTestMode, role, httpClient, requestBuilder, clientName, maxUploadRetries, null);
+  }
+
+  /**
+   * Constructor with proxy properties support
+   *
+   * @param isTestMode whether we're under test mode
+   * @param role Snowflake role used by the Client
+   * @param httpClient http client reference
+   * @param requestBuilder request builder to build the HTTP request
+   * @param clientName the client name
+   * @param maxUploadRetries maximum number of upload retries
+   * @param proxyProperties proxy properties for HTTP client configuration
+   */
+  StreamingIngestStage(
+      boolean isTestMode,
+      String role,
+      CloseableHttpClient httpClient,
+      RequestBuilder requestBuilder,
+      String clientName,
+      int maxUploadRetries,
+      Properties proxyProperties)
+      throws SnowflakeSQLException, IOException {
     this.httpClient = httpClient;
     this.role = role;
     this.requestBuilder = requestBuilder;
     this.clientName = clientName;
-    this.proxyProperties = generateProxyPropertiesForJDBC();
+    this.proxyProperties = proxyProperties != null ? proxyProperties : generateProxyPropertiesForJDBC();
     this.maxUploadRetries = maxUploadRetries;
 
     if (!isTestMode) {
@@ -129,7 +152,7 @@ class StreamingIngestStage {
       SnowflakeFileTransferMetadataWithAge testMetadata,
       int maxRetryCount)
       throws SnowflakeSQLException, IOException {
-    this(isTestMode, role, httpClient, requestBuilder, clientName, maxRetryCount);
+    this(isTestMode, role, httpClient, requestBuilder, clientName, maxRetryCount, null);
     if (!isTestMode) {
       throw new SFException(ErrorCode.INTERNAL_ERROR);
     }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/StreamingIngestStage.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/StreamingIngestStage.java
@@ -125,7 +125,8 @@ class StreamingIngestStage {
     this.role = role;
     this.requestBuilder = requestBuilder;
     this.clientName = clientName;
-    this.proxyProperties = proxyProperties != null ? proxyProperties : generateProxyPropertiesForJDBC();
+    this.proxyProperties =
+        proxyProperties != null ? proxyProperties : generateProxyPropertiesForJDBC();
     this.maxUploadRetries = maxUploadRetries;
 
     if (!isTestMode) {

--- a/src/main/java/net/snowflake/ingest/utils/HttpClientSettingsKey.java
+++ b/src/main/java/net/snowflake/ingest/utils/HttpClientSettingsKey.java
@@ -45,7 +45,7 @@ public class HttpClientSettingsKey implements Serializable {
     this.proxyUser = !isNullOrEmpty(proxyUser) ? proxyUser.trim() : "";
     this.proxyPassword = !isNullOrEmpty(proxyPassword) ? proxyPassword.trim() : "";
 
-    LOGGER.debug("Created HttpClientSettingsKey with proxy configuration for account: {}. Host: {}, Port: {}, User: {}, NonProxyHosts: {}",
+    LOGGER.trace("Created HttpClientSettingsKey with proxy configuration for account: {}. Host: {}, Port: {}, User: {}, NonProxyHosts: {}",
             this.accountName, this.proxyHost, this.proxyPort,
             !isNullOrEmpty(this.proxyUser) ? "set" : "not set",
             !isNullOrEmpty(this.nonProxyHosts) ? this.nonProxyHosts : "not set");

--- a/src/main/java/net/snowflake/ingest/utils/HttpClientSettingsKey.java
+++ b/src/main/java/net/snowflake/ingest/utils/HttpClientSettingsKey.java
@@ -27,16 +27,14 @@ public class HttpClientSettingsKey implements Serializable {
   private String proxyPassword = "";
   private String accountName = "";
 
-  /**
-   * Constructor for proxy configuration
-   */
+  /** Constructor for proxy configuration */
   public HttpClientSettingsKey(
-          String accountName,
-          String proxyHost,
-          int proxyPort,
-          String nonProxyHosts,
-          String proxyUser,
-          String proxyPassword) {
+      String accountName,
+      String proxyHost,
+      int proxyPort,
+      String nonProxyHosts,
+      String proxyUser,
+      String proxyPassword) {
     this.useProxy = true;
     this.accountName = !isNullOrEmpty(accountName) ? accountName.trim() : "";
     this.proxyHost = !isNullOrEmpty(proxyHost) ? proxyHost.trim() : "";
@@ -45,20 +43,24 @@ public class HttpClientSettingsKey implements Serializable {
     this.proxyUser = !isNullOrEmpty(proxyUser) ? proxyUser.trim() : "";
     this.proxyPassword = !isNullOrEmpty(proxyPassword) ? proxyPassword.trim() : "";
 
-    LOGGER.trace("Created HttpClientSettingsKey with proxy configuration for account: {}. Host: {}, Port: {}, User: {}, NonProxyHosts: {}",
-            this.accountName, this.proxyHost, this.proxyPort,
-            !isNullOrEmpty(this.proxyUser) ? "set" : "not set",
-            !isNullOrEmpty(this.nonProxyHosts) ? this.nonProxyHosts : "not set");
+    LOGGER.trace(
+        "Created HttpClientSettingsKey with proxy configuration for account: {}. Host: {}, Port:"
+            + " {}, User: {}, NonProxyHosts: {}",
+        this.accountName,
+        this.proxyHost,
+        this.proxyPort,
+        !isNullOrEmpty(this.proxyUser) ? "set" : "not set",
+        !isNullOrEmpty(this.nonProxyHosts) ? this.nonProxyHosts : "not set");
   }
 
-  /**
-   * Constructor for non-proxy configuration
-   */
+  /** Constructor for non-proxy configuration */
   public HttpClientSettingsKey(String accountName) {
     this.useProxy = false;
     this.accountName = !isNullOrEmpty(accountName) ? accountName.trim() : "";
 
-    LOGGER.debug("Created HttpClientSettingsKey without proxy configuration for account: {}", this.accountName);
+    LOGGER.debug(
+        "Created HttpClientSettingsKey without proxy configuration for account: {}",
+        this.accountName);
   }
 
   @Override
@@ -68,18 +70,19 @@ public class HttpClientSettingsKey implements Serializable {
 
     HttpClientSettingsKey that = (HttpClientSettingsKey) obj;
 
-    return useProxy == that.useProxy &&
-            proxyPort == that.proxyPort &&
-            Objects.equals(accountName, that.accountName) &&
-            Objects.equals(proxyHost, that.proxyHost) &&
-            Objects.equals(nonProxyHosts, that.nonProxyHosts) &&
-            Objects.equals(proxyUser, that.proxyUser) &&
-            Objects.equals(proxyPassword, that.proxyPassword);
+    return useProxy == that.useProxy
+        && proxyPort == that.proxyPort
+        && Objects.equals(accountName, that.accountName)
+        && Objects.equals(proxyHost, that.proxyHost)
+        && Objects.equals(nonProxyHosts, that.nonProxyHosts)
+        && Objects.equals(proxyUser, that.proxyUser)
+        && Objects.equals(proxyPassword, that.proxyPassword);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(useProxy, accountName, proxyHost, proxyPort, nonProxyHosts, proxyUser, proxyPassword);
+    return Objects.hash(
+        useProxy, accountName, proxyHost, proxyPort, nonProxyHosts, proxyUser, proxyPassword);
   }
 
   public boolean usesProxy() {
@@ -112,14 +115,25 @@ public class HttpClientSettingsKey implements Serializable {
 
   @Override
   public String toString() {
-    return "HttpClientSettingsKey[" +
-            "accountName='" + accountName + '\'' +
-            ", useProxy=" + useProxy +
-            ", proxyHost='" + proxyHost + '\'' +
-            ", proxyPort=" + proxyPort +
-            ", nonProxyHosts='" + nonProxyHosts + '\'' +
-            ", proxyUser='" + proxyUser + '\'' +
-            ", proxyPassword=" + (proxyPassword.isEmpty() ? "not set" : "set") +
-            ']';
+    return "HttpClientSettingsKey["
+        + "accountName='"
+        + accountName
+        + '\''
+        + ", useProxy="
+        + useProxy
+        + ", proxyHost='"
+        + proxyHost
+        + '\''
+        + ", proxyPort="
+        + proxyPort
+        + ", nonProxyHosts='"
+        + nonProxyHosts
+        + '\''
+        + ", proxyUser='"
+        + proxyUser
+        + '\''
+        + ", proxyPassword="
+        + (proxyPassword.isEmpty() ? "not set" : "set")
+        + ']';
   }
 }

--- a/src/main/java/net/snowflake/ingest/utils/HttpClientSettingsKey.java
+++ b/src/main/java/net/snowflake/ingest/utils/HttpClientSettingsKey.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2012-2017 Snowflake Computing Inc. All rights reserved.
+ */
+
+package net.snowflake.ingest.utils;
+
+import static net.snowflake.ingest.utils.Utils.isNullOrEmpty;
+
+import java.io.Serializable;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class defines all parameters needed to create an HttpClient object for the ingest service.
+ * It is used as the key for the static hashmap of reusable http clients.
+ */
+public class HttpClientSettingsKey implements Serializable {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(HttpClientSettingsKey.class);
+
+  private boolean useProxy;
+  private String proxyHost = "";
+  private int proxyPort = 0;
+  private String nonProxyHosts = "";
+  private String proxyUser = "";
+  private String proxyPassword = "";
+  private String accountName = "";
+
+  /**
+   * Constructor for proxy configuration
+   */
+  public HttpClientSettingsKey(
+          String accountName,
+          String proxyHost,
+          int proxyPort,
+          String nonProxyHosts,
+          String proxyUser,
+          String proxyPassword) {
+    this.useProxy = true;
+    this.accountName = !isNullOrEmpty(accountName) ? accountName.trim() : "";
+    this.proxyHost = !isNullOrEmpty(proxyHost) ? proxyHost.trim() : "";
+    this.proxyPort = proxyPort;
+    this.nonProxyHosts = !isNullOrEmpty(nonProxyHosts) ? nonProxyHosts.trim() : "";
+    this.proxyUser = !isNullOrEmpty(proxyUser) ? proxyUser.trim() : "";
+    this.proxyPassword = !isNullOrEmpty(proxyPassword) ? proxyPassword.trim() : "";
+
+    LOGGER.debug("Created HttpClientSettingsKey with proxy configuration for account: {}. Host: {}, Port: {}, User: {}, NonProxyHosts: {}",
+            this.accountName, this.proxyHost, this.proxyPort,
+            !isNullOrEmpty(this.proxyUser) ? "set" : "not set",
+            !isNullOrEmpty(this.nonProxyHosts) ? this.nonProxyHosts : "not set");
+  }
+
+  /**
+   * Constructor for non-proxy configuration
+   */
+  public HttpClientSettingsKey(String accountName) {
+    this.useProxy = false;
+    this.accountName = !isNullOrEmpty(accountName) ? accountName.trim() : "";
+
+    LOGGER.debug("Created HttpClientSettingsKey without proxy configuration for account: {}", this.accountName);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (obj == null || getClass() != obj.getClass()) return false;
+
+    HttpClientSettingsKey that = (HttpClientSettingsKey) obj;
+
+    return useProxy == that.useProxy &&
+            proxyPort == that.proxyPort &&
+            Objects.equals(accountName, that.accountName) &&
+            Objects.equals(proxyHost, that.proxyHost) &&
+            Objects.equals(nonProxyHosts, that.nonProxyHosts) &&
+            Objects.equals(proxyUser, that.proxyUser) &&
+            Objects.equals(proxyPassword, that.proxyPassword);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(useProxy, accountName, proxyHost, proxyPort, nonProxyHosts, proxyUser, proxyPassword);
+  }
+
+  public boolean usesProxy() {
+    return this.useProxy;
+  }
+
+  public String getAccountName() {
+    return this.accountName;
+  }
+
+  public String getProxyHost() {
+    return this.proxyHost;
+  }
+
+  public int getProxyPort() {
+    return this.proxyPort;
+  }
+
+  public String getProxyUser() {
+    return this.proxyUser;
+  }
+
+  public String getProxyPassword() {
+    return this.proxyPassword;
+  }
+
+  public String getNonProxyHosts() {
+    return this.nonProxyHosts;
+  }
+
+  @Override
+  public String toString() {
+    return "HttpClientSettingsKey[" +
+            "accountName='" + accountName + '\'' +
+            ", useProxy=" + useProxy +
+            ", proxyHost='" + proxyHost + '\'' +
+            ", proxyPort=" + proxyPort +
+            ", nonProxyHosts='" + nonProxyHosts + '\'' +
+            ", proxyUser='" + proxyUser + '\'' +
+            ", proxyPassword=" + (proxyPassword.isEmpty() ? "not set" : "set") +
+            ']';
+  }
+}

--- a/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
+++ b/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
@@ -10,8 +10,10 @@ import java.security.Security;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Pattern;
@@ -66,7 +68,8 @@ public class HttpUtil {
    */
   private static final int MAX_RETRIES = 10;
 
-  private static volatile CloseableHttpClient httpClient;
+  private static final Map<HttpClientSettingsKey, CloseableHttpClient> httpClientCache =
+      new ConcurrentHashMap<>();
 
   private static PoolingHttpClientConnectionManager connectionManager;
 
@@ -100,28 +103,100 @@ public class HttpUtil {
   // Only connections that are currently owned, not checked out, are subject to idle timeouts.
   private static final int DEFAULT_IDLE_CONNECTION_TIMEOUT_SECONDS = 30;
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(HttpUtil.class);
+
   /**
-   * @param {@code String} account name to connect to (excluding snowflakecomputing.com domain)
+   * Get HttpClient with proxy properties support
+   *
+   * @param accountName account name to connect to (excluding snowflakecomputing.com domain)
+   * @param proxyProperties proxy properties, can be null
+   * @return Instance of CloseableHttpClient
+   */
+  public static CloseableHttpClient getHttpClient(String accountName, Properties proxyProperties) {
+
+    HttpClientSettingsKey key = createHttpClientSettingsKey(accountName, proxyProperties);
+
+    CloseableHttpClient client = httpClientCache.get(key);
+    // todo: this is for testing phase
+    if (client != null) {
+      LOGGER.info("Reusing existing HTTP client for account: {}, key: {}", accountName, key);
+      return client;
+    }
+
+    LOGGER.info("No existing HTTP client found for account: {}, key: {}. Creating new HTTP client.", accountName, key);
+    return httpClientCache.computeIfAbsent(key, HttpUtil::buildHttpClient);
+  }
+
+  /**
+   * @param accountName account name to connect to (excluding snowflakecomputing.com domain)
    * @return Instance of CloseableHttpClient
    */
   public static CloseableHttpClient getHttpClient(String accountName) {
-    if (httpClient == null) {
-      synchronized (HttpUtil.class) {
-        if (httpClient == null) {
-          initHttpClient(accountName);
-        }
-      }
-    }
-
-    initIdleConnectionMonitoringThread();
-
-    return httpClient;
+    return getHttpClient(accountName, null);
   }
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(HttpUtil.class);
+  /**
+   * Create HttpClientSettingsKey from account name and proxy properties
+   */
+  private static HttpClientSettingsKey createHttpClientSettingsKey(String accountName, Properties proxyProperties) {
 
-  private static void initHttpClient(String accountName) {
+    if (proxyProperties != null && proxyProperties.containsKey(SFSessionProperty.USE_PROXY.getPropertyKey())) {
 
+      Boolean useProxy = Boolean.valueOf(proxyProperties.getProperty(SFSessionProperty.USE_PROXY.getPropertyKey()));
+
+      if (useProxy) {
+        String proxyHost = proxyProperties.getProperty(SFSessionProperty.PROXY_HOST.getPropertyKey(), "");
+        String proxyPortStr = proxyProperties.getProperty(SFSessionProperty.PROXY_PORT.getPropertyKey(), "0");
+        int proxyPort = 0;
+        try {
+          proxyPort = Integer.parseInt(proxyPortStr);
+        } catch (NumberFormatException e) {
+          throw new IllegalArgumentException(
+              "Invalid proxy port: '" + proxyPortStr + "'. Proxy port must be a valid integer.", e);
+        }
+        String nonProxyHosts = proxyProperties.getProperty(SFSessionProperty.NON_PROXY_HOSTS.getPropertyKey(), "");
+        String proxyUser = proxyProperties.getProperty(SFSessionProperty.PROXY_USER.getPropertyKey(), "");
+        String proxyPassword = proxyProperties.getProperty(SFSessionProperty.PROXY_PASSWORD.getPropertyKey(), "");
+        
+        LOGGER.info("Creating HTTP client settings key with proxy configuration from properties for account: {}. Proxy host: {}, port: {}, user: {}, nonProxyHosts: {}", 
+                   accountName, proxyHost, proxyPort, isNullOrEmpty(proxyUser) ? "not set" : "set", isNullOrEmpty(nonProxyHosts) ? "not set" : nonProxyHosts);
+        return new HttpClientSettingsKey(accountName, proxyHost, proxyPort, nonProxyHosts, proxyUser, proxyPassword);
+      } else {
+        LOGGER.info("Creating HTTP client settings key with proxy explicitly disabled via properties for account: {}", accountName);
+      }
+    }
+    
+    // Check system properties for proxy configuration (backward compatibility)
+    if ("true".equalsIgnoreCase(System.getProperty(USE_PROXY)) && !shouldBypassProxy(accountName)) {
+      String proxyHost = System.getProperty(PROXY_HOST, "");
+      String proxyPortStr = System.getProperty(PROXY_PORT, "0");
+      int proxyPort = 0;
+      try {
+        proxyPort = Integer.parseInt(proxyPortStr);
+      } catch (NumberFormatException e) {
+        throw new IllegalArgumentException(
+            "Invalid proxy port: '" + proxyPortStr + "'. Proxy port must be a valid integer.", e);
+      }
+      String nonProxyHosts = System.getProperty(NON_PROXY_HOSTS, "");
+      String proxyUser = System.getProperty(HTTP_PROXY_USER, "");
+      String proxyPassword = System.getProperty(HTTP_PROXY_PASSWORD, "");
+      
+      LOGGER.info("Creating HTTP client settings key with proxy configuration from system properties for account: {}. Proxy host: {}, port: {}, user: {}, nonProxyHosts: {}", 
+                 accountName, proxyHost, proxyPort, isNullOrEmpty(proxyUser) ? "not set" : "set", isNullOrEmpty(nonProxyHosts) ? "not set" : nonProxyHosts);
+      return new HttpClientSettingsKey(accountName, proxyHost, proxyPort, nonProxyHosts, proxyUser, proxyPassword);
+    }
+    
+    // No proxy configuration
+    LOGGER.info("Creating HTTP client settings key without proxy configuration for account: {}", accountName);
+    return new HttpClientSettingsKey(accountName);
+  }
+
+  /**
+   * Build HttpClient based on the settings key
+   */
+  private static CloseableHttpClient buildHttpClient(HttpClientSettingsKey key) {
+    LOGGER.info("Building new HTTP client for key: {}", key);
+    
     Security.setProperty("ocsp.enable", "true");
 
     SSLContext sslContext = SSLContexts.createDefault();
@@ -167,34 +242,45 @@ public class HttpUtil {
             .setDefaultRequestConfig(requestConfig);
 
     // proxy settings
-    if ("true".equalsIgnoreCase(System.getProperty(USE_PROXY)) && !shouldBypassProxy(accountName)) {
-      if (System.getProperty(PROXY_PORT) == null) {
-        throw new IllegalArgumentException(
-            "proxy port number is not provided, please assign proxy port to http.proxyPort option");
-      }
-      if (System.getProperty(PROXY_HOST) == null) {
+    if (key.usesProxy()) {
+      LOGGER.info("Configuring HTTP client with proxy settings. Host: {}, Port: {}", key.getProxyHost(), key.getProxyPort());
+      
+      if (isNullOrEmpty(key.getProxyHost())) {
         throw new IllegalArgumentException(
             "proxy host IP is not provided, please assign proxy host IP to http.proxyHost option");
       }
-      String proxyHost = System.getProperty(PROXY_HOST);
-      int proxyPort = Integer.parseInt(System.getProperty(PROXY_PORT));
+      if (key.getProxyPort() <= 0) {
+        throw new IllegalArgumentException(
+            "proxy port number is not provided, please assign proxy port to http.proxyPort option");
+      }
+      
+      String proxyHost = key.getProxyHost();
+      int proxyPort = key.getProxyPort();
       HttpHost proxy = new HttpHost(proxyHost, proxyPort, PROXY_SCHEME);
       DefaultProxyRoutePlanner routePlanner = new DefaultProxyRoutePlanner(proxy);
       clientBuilder = clientBuilder.setRoutePlanner(routePlanner);
 
       // Check if proxy username and password are set
-      final String proxyUser = System.getProperty(HTTP_PROXY_USER);
-      final String proxyPassword = System.getProperty(HTTP_PROXY_PASSWORD);
+      final String proxyUser = key.getProxyUser();
+      final String proxyPassword = key.getProxyPassword();
       if (!isNullOrEmpty(proxyUser) && !isNullOrEmpty(proxyPassword)) {
+        LOGGER.info("Configuring HTTP client with proxy authentication credentials");
         Credentials credentials = new UsernamePasswordCredentials(proxyUser, proxyPassword);
         AuthScope authScope = new AuthScope(proxyHost, proxyPort);
         CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
         credentialsProvider.setCredentials(authScope, credentials);
         clientBuilder = clientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+      } else {
+        LOGGER.info("HTTP client configured with proxy but no authentication credentials provided");
       }
+    } else {
+      LOGGER.info("Configuring HTTP client without proxy settings");
     }
 
-    httpClient = clientBuilder.build();
+    CloseableHttpClient httpClient = clientBuilder.build();
+    initIdleConnectionMonitoringThread();
+    LOGGER.info("Successfully built new HTTP client for key: {}", key);
+    return httpClient;
   }
 
   /** Starts a daemon thread to monitor idle connections in http connection manager. */
@@ -324,6 +410,8 @@ public class HttpUtil {
   public static Properties generateProxyPropertiesForJDBC() {
     Properties proxyProperties = new Properties();
     if (Boolean.parseBoolean(System.getProperty(USE_PROXY))) {
+      LOGGER.info("Generating proxy properties for JDBC from system properties");
+      
       if (isNullOrEmpty(System.getProperty(PROXY_PORT))) {
         throw new IllegalArgumentException(
             "proxy port number is not provided, please assign proxy port to http.proxyPort option");
@@ -340,19 +428,28 @@ public class HttpUtil {
       proxyProperties.put(
           SFSessionProperty.PROXY_PORT.getPropertyKey(), System.getProperty(PROXY_PORT));
 
+      LOGGER.info("Generated proxy properties - Host: {}, Port: {}", 
+                 System.getProperty(PROXY_HOST), System.getProperty(PROXY_PORT));
+
       // Check if proxy username and password are set
       final String proxyUser = System.getProperty(HTTP_PROXY_USER);
       final String proxyPassword = System.getProperty(HTTP_PROXY_PASSWORD);
       if (!isNullOrEmpty(proxyUser) && !isNullOrEmpty(proxyPassword)) {
         proxyProperties.put(SFSessionProperty.PROXY_USER.getPropertyKey(), proxyUser);
         proxyProperties.put(SFSessionProperty.PROXY_PASSWORD.getPropertyKey(), proxyPassword);
+        LOGGER.info("Added proxy authentication credentials to generated properties");
+      } else {
+        LOGGER.info("No proxy authentication credentials found in system properties");
       }
 
       // Check if http.nonProxyHosts was set
       final String nonProxyHosts = System.getProperty(NON_PROXY_HOSTS);
       if (!isNullOrEmpty(nonProxyHosts)) {
         proxyProperties.put(SFSessionProperty.NON_PROXY_HOSTS.getPropertyKey(), nonProxyHosts);
+        LOGGER.info("Added nonProxyHosts to generated properties: {}", nonProxyHosts);
       }
+    } else {
+      LOGGER.info("System property {} is not set to true, generating empty proxy properties", USE_PROXY);
     }
     return proxyProperties;
   }
@@ -420,7 +517,33 @@ public class HttpUtil {
 
   /** Shuts down the daemon thread. */
   public static void shutdownHttpConnectionManagerDaemonThread() {
-    idleConnectionMonitorThread.shutdown();
+    idleConnectionMonitorThreadLock.lock();
+    try {
+      if (idleConnectionMonitorThread != null) {
+        idleConnectionMonitorThread.shutdown();
+        idleConnectionMonitorThread = null;
+      }
+    } finally {
+      idleConnectionMonitorThreadLock.unlock();
+    }
+  }
+
+  /**
+   * Close all cached HTTP clients and clear the cache
+   */
+  public static void closeAllHttpClients() {
+    LOGGER.info("Closing all cached HTTP clients. Total clients in cache: {}", httpClientCache.size());
+    for (Map.Entry<HttpClientSettingsKey, CloseableHttpClient> entry : httpClientCache.entrySet()) {
+      try {
+        LOGGER.debug("Closing HTTP client for key: {}", entry.getKey());
+        entry.getValue().close();
+      } catch (Exception e) {
+        LOGGER.warn("Error closing HTTP client for key: {}", entry.getKey(), e);
+      }
+    }
+    httpClientCache.clear();
+    LOGGER.info("All cached HTTP clients closed and cache cleared");
+    shutdownHttpConnectionManagerDaemonThread();
   }
 
   /** Create Pool stats for a route */
@@ -445,7 +568,15 @@ public class HttpUtil {
    */
   public static Boolean shouldBypassProxy(String accountName) {
     String targetHost = accountName + SNOWFLAKE_DOMAIN_NAME;
-    return System.getProperty(NON_PROXY_HOSTS) != null && isInNonProxyHosts(targetHost);
+    boolean shouldBypass = System.getProperty(NON_PROXY_HOSTS) != null && isInNonProxyHosts(targetHost);
+    
+    if (shouldBypass) {
+      LOGGER.info("Account {} ({}) matches nonProxyHosts pattern. Bypassing proxy.", accountName, targetHost);
+    } else {
+      LOGGER.debug("Account {} ({}) does not match nonProxyHosts pattern or nonProxyHosts not set.", accountName, targetHost);
+    }
+    
+    return shouldBypass;
   }
 
   /**

--- a/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
+++ b/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
@@ -537,6 +537,7 @@ public class HttpUtil {
    * Close all cached HTTP clients and clear the cache
    */
   public static void closeAllHttpClients() {
+    // for use in test
     LOGGER.info("Closing all cached HTTP clients. Total clients in cache: {}", httpClientCache.size());
     for (Map.Entry<HttpClientSettingsKey, CloseableHttpClient> entry : httpClientCache.entrySet()) {
       try {
@@ -570,6 +571,16 @@ public class HttpUtil {
   /**
    * Changes the account name to the format accountName.snowflakecomputing.com then returns a
    * boolean to indicate if we should go through a proxy or not.
+   * This is a convenience method for existing tests that calls the two-parameter version with null properties.
+   */
+  public static Boolean shouldBypassProxy(String accountName) {
+    return shouldBypassProxy(accountName, null);
+  }
+
+  /**
+   * Changes the account name to the format accountName.snowflakecomputing.com then returns a
+   * boolean to indicate if we should go through a proxy or not.
+   * Checks both system properties and provided proxy properties for non-proxy hosts configuration.
    */
   public static Boolean shouldBypassProxy(String accountName, Properties proxyProperties) {
     String targetHost = accountName + SNOWFLAKE_DOMAIN_NAME;

--- a/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
+++ b/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
@@ -123,7 +123,10 @@ public class HttpUtil {
       return client;
     }
 
-    LOGGER.debug("No existing HTTP client found for account: {}, key: {}. Creating new HTTP client.", accountName, key);
+    LOGGER.debug(
+        "No existing HTTP client found for account: {}, key: {}. Creating new HTTP client.",
+        accountName,
+        key);
     return httpClientCache.computeIfAbsent(key, HttpUtil::buildHttpClient);
   }
 
@@ -135,18 +138,22 @@ public class HttpUtil {
     return getHttpClient(accountName, null);
   }
 
-  /**
-   * Create HttpClientSettingsKey from account name and proxy properties
-   */
-  private static HttpClientSettingsKey createHttpClientSettingsKey(String accountName, Properties proxyProperties) {
+  /** Create HttpClientSettingsKey from account name and proxy properties */
+  private static HttpClientSettingsKey createHttpClientSettingsKey(
+      String accountName, Properties proxyProperties) {
 
-    if (proxyProperties != null && proxyProperties.containsKey(SFSessionProperty.USE_PROXY.getPropertyKey())) {
+    if (proxyProperties != null
+        && proxyProperties.containsKey(SFSessionProperty.USE_PROXY.getPropertyKey())) {
 
-      Boolean useProxy = Boolean.valueOf(proxyProperties.getProperty(SFSessionProperty.USE_PROXY.getPropertyKey()));
+      Boolean useProxy =
+          Boolean.valueOf(
+              proxyProperties.getProperty(SFSessionProperty.USE_PROXY.getPropertyKey()));
 
       if (useProxy) {
-        String proxyHost = proxyProperties.getProperty(SFSessionProperty.PROXY_HOST.getPropertyKey(), "");
-        String proxyPortStr = proxyProperties.getProperty(SFSessionProperty.PROXY_PORT.getPropertyKey(), "0");
+        String proxyHost =
+            proxyProperties.getProperty(SFSessionProperty.PROXY_HOST.getPropertyKey(), "");
+        String proxyPortStr =
+            proxyProperties.getProperty(SFSessionProperty.PROXY_PORT.getPropertyKey(), "0");
         int proxyPort = 0;
         try {
           proxyPort = Integer.parseInt(proxyPortStr);
@@ -154,25 +161,42 @@ public class HttpUtil {
           throw new IllegalArgumentException(
               "Invalid proxy port: '" + proxyPortStr + "'. Proxy port must be a valid integer.", e);
         }
-        String nonProxyHosts = proxyProperties.getProperty(SFSessionProperty.NON_PROXY_HOSTS.getPropertyKey(), "");
-        String proxyUser = proxyProperties.getProperty(SFSessionProperty.PROXY_USER.getPropertyKey(), "");
-        String proxyPassword = proxyProperties.getProperty(SFSessionProperty.PROXY_PASSWORD.getPropertyKey(), "");
-        
+        String nonProxyHosts =
+            proxyProperties.getProperty(SFSessionProperty.NON_PROXY_HOSTS.getPropertyKey(), "");
+        String proxyUser =
+            proxyProperties.getProperty(SFSessionProperty.PROXY_USER.getPropertyKey(), "");
+        String proxyPassword =
+            proxyProperties.getProperty(SFSessionProperty.PROXY_PASSWORD.getPropertyKey(), "");
+
         if (shouldBypassProxy(accountName, proxyProperties)) {
-          LOGGER.debug("Account {} matches nonProxyHosts pattern from system properties. Bypassing proxy despite proxyProperties configuration.", accountName);
+          LOGGER.debug(
+              "Account {} matches nonProxyHosts pattern from system properties. Bypassing proxy"
+                  + " despite proxyProperties configuration.",
+              accountName);
           return new HttpClientSettingsKey(accountName);
         }
-        
-        LOGGER.trace("Creating HTTP client settings key with proxy configuration from properties for account: {}. Proxy host: {}, port: {}, user: {}, nonProxyHosts: {}",
-                   accountName, proxyHost, proxyPort, isNullOrEmpty(proxyUser) ? "not set" : "set", isNullOrEmpty(nonProxyHosts) ? "not set" : nonProxyHosts);
-        return new HttpClientSettingsKey(accountName, proxyHost, proxyPort, nonProxyHosts, proxyUser, proxyPassword);
+
+        LOGGER.trace(
+            "Creating HTTP client settings key with proxy configuration from properties for"
+                + " account: {}. Proxy host: {}, port: {}, user: {}, nonProxyHosts: {}",
+            accountName,
+            proxyHost,
+            proxyPort,
+            isNullOrEmpty(proxyUser) ? "not set" : "set",
+            isNullOrEmpty(nonProxyHosts) ? "not set" : nonProxyHosts);
+        return new HttpClientSettingsKey(
+            accountName, proxyHost, proxyPort, nonProxyHosts, proxyUser, proxyPassword);
       } else {
-        LOGGER.debug("Creating HTTP client settings key with proxy explicitly disabled via properties for account: {}", accountName);
+        LOGGER.debug(
+            "Creating HTTP client settings key with proxy explicitly disabled via properties for"
+                + " account: {}",
+            accountName);
       }
     }
-    
+
     // Check system properties for proxy configuration (backward compatibility)
-    if ("true".equalsIgnoreCase(System.getProperty(USE_PROXY)) && !shouldBypassProxy(accountName, proxyProperties)) {
+    if ("true".equalsIgnoreCase(System.getProperty(USE_PROXY))
+        && !shouldBypassProxy(accountName, proxyProperties)) {
       String proxyHost = System.getProperty(PROXY_HOST, "");
       String proxyPortStr = System.getProperty(PROXY_PORT, "0");
       int proxyPort = 0;
@@ -185,20 +209,27 @@ public class HttpUtil {
       String nonProxyHosts = System.getProperty(NON_PROXY_HOSTS, "");
       String proxyUser = System.getProperty(HTTP_PROXY_USER, "");
       String proxyPassword = System.getProperty(HTTP_PROXY_PASSWORD, "");
-      
-      LOGGER.trace("Creating HTTP client settings key with proxy configuration from system properties for account: {}. Proxy host: {}, port: {}, user: {}, nonProxyHosts: {}",
-                 accountName, proxyHost, proxyPort, isNullOrEmpty(proxyUser) ? "not set" : "set", isNullOrEmpty(nonProxyHosts) ? "not set" : nonProxyHosts);
-      return new HttpClientSettingsKey(accountName, proxyHost, proxyPort, nonProxyHosts, proxyUser, proxyPassword);
+
+      LOGGER.trace(
+          "Creating HTTP client settings key with proxy configuration from system properties for"
+              + " account: {}. Proxy host: {}, port: {}, user: {}, nonProxyHosts: {}",
+          accountName,
+          proxyHost,
+          proxyPort,
+          isNullOrEmpty(proxyUser) ? "not set" : "set",
+          isNullOrEmpty(nonProxyHosts) ? "not set" : nonProxyHosts);
+      return new HttpClientSettingsKey(
+          accountName, proxyHost, proxyPort, nonProxyHosts, proxyUser, proxyPassword);
     }
-    
+
     // No proxy configuration
-    LOGGER.debug("Creating HTTP client settings key without proxy configuration for account: {}", accountName);
+    LOGGER.debug(
+        "Creating HTTP client settings key without proxy configuration for account: {}",
+        accountName);
     return new HttpClientSettingsKey(accountName);
   }
 
-  /**
-   * Build HttpClient based on the settings key
-   */
+  /** Build HttpClient based on the settings key */
   private static CloseableHttpClient buildHttpClient(HttpClientSettingsKey key) {
     LOGGER.info("Building new HTTP client");
 
@@ -248,8 +279,11 @@ public class HttpUtil {
 
     // proxy settings
     if (key.usesProxy()) {
-      LOGGER.debug("Configuring HTTP client with proxy settings. Host: {}, Port: {}", key.getProxyHost(), key.getProxyPort());
-      
+      LOGGER.debug(
+          "Configuring HTTP client with proxy settings. Host: {}, Port: {}",
+          key.getProxyHost(),
+          key.getProxyPort());
+
       if (isNullOrEmpty(key.getProxyHost())) {
         throw new IllegalArgumentException(
             "proxy host IP is not provided, please assign proxy host IP to http.proxyHost option");
@@ -258,7 +292,7 @@ public class HttpUtil {
         throw new IllegalArgumentException(
             "proxy port number is not provided, please assign proxy port to http.proxyPort option");
       }
-      
+
       String proxyHost = key.getProxyHost();
       int proxyPort = key.getProxyPort();
       HttpHost proxy = new HttpHost(proxyHost, proxyPort, PROXY_SCHEME);
@@ -276,7 +310,8 @@ public class HttpUtil {
         credentialsProvider.setCredentials(authScope, credentials);
         clientBuilder = clientBuilder.setDefaultCredentialsProvider(credentialsProvider);
       } else {
-        LOGGER.debug("HTTP client configured with proxy but no authentication credentials provided");
+        LOGGER.debug(
+            "HTTP client configured with proxy but no authentication credentials provided");
       }
     } else {
       LOGGER.debug("Configuring HTTP client without proxy settings");
@@ -416,7 +451,7 @@ public class HttpUtil {
     Properties proxyProperties = new Properties();
     if (Boolean.parseBoolean(System.getProperty(USE_PROXY))) {
       LOGGER.debug("Generating proxy properties for JDBC from system properties");
-      
+
       if (isNullOrEmpty(System.getProperty(PROXY_PORT))) {
         throw new IllegalArgumentException(
             "proxy port number is not provided, please assign proxy port to http.proxyPort option");
@@ -433,8 +468,10 @@ public class HttpUtil {
       proxyProperties.put(
           SFSessionProperty.PROXY_PORT.getPropertyKey(), System.getProperty(PROXY_PORT));
 
-      LOGGER.debug("Generated proxy properties - Host: {}, Port: {}",
-                 System.getProperty(PROXY_HOST), System.getProperty(PROXY_PORT));
+      LOGGER.debug(
+          "Generated proxy properties - Host: {}, Port: {}",
+          System.getProperty(PROXY_HOST),
+          System.getProperty(PROXY_PORT));
 
       // Check if proxy username and password are set
       final String proxyUser = System.getProperty(HTTP_PROXY_USER);
@@ -454,7 +491,8 @@ public class HttpUtil {
         LOGGER.debug("Added nonProxyHosts to generated properties: {}", nonProxyHosts);
       }
     } else {
-      LOGGER.debug("System property {} is not set to true, generating empty proxy properties", USE_PROXY);
+      LOGGER.debug(
+          "System property {} is not set to true, generating empty proxy properties", USE_PROXY);
     }
     return proxyProperties;
   }
@@ -533,12 +571,11 @@ public class HttpUtil {
     }
   }
 
-  /**
-   * Close all cached HTTP clients and clear the cache
-   */
+  /** Close all cached HTTP clients and clear the cache */
   public static void closeAllHttpClients() {
     // for use in test
-    LOGGER.info("Closing all cached HTTP clients. Total clients in cache: {}", httpClientCache.size());
+    LOGGER.info(
+        "Closing all cached HTTP clients. Total clients in cache: {}", httpClientCache.size());
     for (Map.Entry<HttpClientSettingsKey, CloseableHttpClient> entry : httpClientCache.entrySet()) {
       try {
         LOGGER.debug("Closing HTTP client for key: {}", entry.getKey());
@@ -570,8 +607,8 @@ public class HttpUtil {
 
   /**
    * Changes the account name to the format accountName.snowflakecomputing.com then returns a
-   * boolean to indicate if we should go through a proxy or not.
-   * This is a convenience method for existing tests that calls the two-parameter version with null properties.
+   * boolean to indicate if we should go through a proxy or not. This is a convenience method for
+   * existing tests that calls the two-parameter version with null properties.
    */
   public static Boolean shouldBypassProxy(String accountName) {
     return shouldBypassProxy(accountName, null);
@@ -579,37 +616,45 @@ public class HttpUtil {
 
   /**
    * Changes the account name to the format accountName.snowflakecomputing.com then returns a
-   * boolean to indicate if we should go through a proxy or not.
-   * Checks both system properties and provided proxy properties for non-proxy hosts configuration.
+   * boolean to indicate if we should go through a proxy or not. Checks both system properties and
+   * provided proxy properties for non-proxy hosts configuration.
    */
   public static Boolean shouldBypassProxy(String accountName, Properties proxyProperties) {
     String targetHost = accountName + SNOWFLAKE_DOMAIN_NAME;
-    
+
     // Check system properties first
     String systemNonProxyHosts = System.getProperty(NON_PROXY_HOSTS);
     if (systemNonProxyHosts != null && isInNonProxyHosts(targetHost, systemNonProxyHosts)) {
-      LOGGER.info("Account {} ({}) matches system nonProxyHosts pattern. Bypassing proxy.", accountName, targetHost);
+      LOGGER.info(
+          "Account {} ({}) matches system nonProxyHosts pattern. Bypassing proxy.",
+          accountName,
+          targetHost);
       return true;
     }
-    
+
     // Check SFSessionProperty.NON_PROXY_HOSTS from proxyProperties if available
     if (proxyProperties != null) {
-      String sessionNonProxyHosts = proxyProperties.getProperty(SFSessionProperty.NON_PROXY_HOSTS.getPropertyKey());
+      String sessionNonProxyHosts =
+          proxyProperties.getProperty(SFSessionProperty.NON_PROXY_HOSTS.getPropertyKey());
       if (sessionNonProxyHosts != null && isInNonProxyHosts(targetHost, sessionNonProxyHosts)) {
-        LOGGER.info("Account {} ({}) matches session nonProxyHosts pattern. Bypassing proxy.", accountName, targetHost);
+        LOGGER.info(
+            "Account {} ({}) matches session nonProxyHosts pattern. Bypassing proxy.",
+            accountName,
+            targetHost);
         return true;
       }
     }
-    
-    LOGGER.debug("Account {} ({}) does not match any nonProxyHosts pattern.", accountName, targetHost);
+
+    LOGGER.debug(
+        "Account {} ({}) does not match any nonProxyHosts pattern.", accountName, targetHost);
     return false;
   }
 
   /**
    * The target hostname input is compared with the hosts in the '|' separated list provided by the
-   * nonProxyHosts parameter using regex. The nonProxyHosts will be used as our Patterns, so we
-   * need to replace the '.' and '*' characters since those are special regex constructs that mean
-   * 'any character,' and 'repeat 0 or more times.'
+   * nonProxyHosts parameter using regex. The nonProxyHosts will be used as our Patterns, so we need
+   * to replace the '.' and '*' characters since those are special regex constructs that mean 'any
+   * character,' and 'repeat 0 or more times.'
    */
   private static Boolean isInNonProxyHosts(String targetHost, String nonProxyHosts) {
     String escapedNonProxyHosts = nonProxyHosts.replace(".", "\\.").replace("*", ".*");

--- a/src/main/java/net/snowflake/ingest/utils/Utils.java
+++ b/src/main/java/net/snowflake/ingest/utils/Utils.java
@@ -220,17 +220,15 @@ public class Utils {
     return properties;
   }
 
-  /**
-   * Check if a property key is proxy-related and should preserve its case
-   */
+  /** Check if a property key is proxy-related and should preserve its case */
   private static boolean isProxyRelatedProperty(String key) {
-    return key.equals(SFSessionProperty.USE_PROXY.getPropertyKey()) ||
-           key.equals(SFSessionProperty.PROXY_HOST.getPropertyKey()) ||
-           key.equals(SFSessionProperty.PROXY_PORT.getPropertyKey()) ||
-           key.equals(SFSessionProperty.PROXY_USER.getPropertyKey()) ||
-           key.equals(SFSessionProperty.PROXY_PASSWORD.getPropertyKey()) ||
-           key.equals(SFSessionProperty.NON_PROXY_HOSTS.getPropertyKey()) ||
-           key.equals(SFSessionProperty.PROXY_PROTOCOL.getPropertyKey());
+    return key.equals(SFSessionProperty.USE_PROXY.getPropertyKey())
+        || key.equals(SFSessionProperty.PROXY_HOST.getPropertyKey())
+        || key.equals(SFSessionProperty.PROXY_PORT.getPropertyKey())
+        || key.equals(SFSessionProperty.PROXY_USER.getPropertyKey())
+        || key.equals(SFSessionProperty.PROXY_PASSWORD.getPropertyKey())
+        || key.equals(SFSessionProperty.NON_PROXY_HOSTS.getPropertyKey())
+        || key.equals(SFSessionProperty.PROXY_PROTOCOL.getPropertyKey());
   }
 
   /** Construct account url from input schema, host and port */

--- a/src/main/java/net/snowflake/ingest/utils/Utils.java
+++ b/src/main/java/net/snowflake/ingest/utils/Utils.java
@@ -139,7 +139,12 @@ public class Utils {
           privateKeyPassphrase = val;
           break;
         default:
-          properties.put(key.toLowerCase(), val);
+          // Preserve case for proxy-related properties that HttpUtil expects
+          if (isProxyRelatedProperty(key)) {
+            properties.put(key, val);
+          } else {
+            properties.put(key.toLowerCase(), val);
+          }
       }
     }
 
@@ -213,6 +218,19 @@ public class Utils {
     properties.put(SFSessionProperty.ALLOW_UNDERSCORES_IN_HOST.getPropertyKey(), "true");
 
     return properties;
+  }
+
+  /**
+   * Check if a property key is proxy-related and should preserve its case
+   */
+  private static boolean isProxyRelatedProperty(String key) {
+    return key.equals(SFSessionProperty.USE_PROXY.getPropertyKey()) ||
+           key.equals(SFSessionProperty.PROXY_HOST.getPropertyKey()) ||
+           key.equals(SFSessionProperty.PROXY_PORT.getPropertyKey()) ||
+           key.equals(SFSessionProperty.PROXY_USER.getPropertyKey()) ||
+           key.equals(SFSessionProperty.PROXY_PASSWORD.getPropertyKey()) ||
+           key.equals(SFSessionProperty.NON_PROXY_HOSTS.getPropertyKey()) ||
+           key.equals(SFSessionProperty.PROXY_PROTOCOL.getPropertyKey());
   }
 
   /** Construct account url from input schema, host and port */

--- a/src/test/java/net/snowflake/ingest/utils/HttpUtilCacheTest.java
+++ b/src/test/java/net/snowflake/ingest/utils/HttpUtilCacheTest.java
@@ -1,0 +1,105 @@
+package net.snowflake.ingest.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+import java.util.Properties;
+import net.snowflake.client.core.SFSessionProperty;
+import net.snowflake.client.jdbc.internal.apache.http.impl.client.CloseableHttpClient;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Test class for HttpUtil caching functionality.
+ * Tests verify that HTTP clients are properly cached based on account name and proxy settings.
+ * Note: Both JDBC and streaming clients now use unified SFSessionProperty constants for proxy configuration.
+ */
+public class HttpUtilCacheTest {
+
+  @After
+  public void tearDown() {
+    // Clean up after each test
+    HttpUtil.closeAllHttpClients();
+  }
+
+  @Test
+  public void testHttpClientCachingWithSameAccount() {
+    String accountName = "testaccount";
+
+    // Get HTTP client twice with same account
+    CloseableHttpClient client1 = HttpUtil.getHttpClient(accountName);
+    CloseableHttpClient client2 = HttpUtil.getHttpClient(accountName);
+
+    // Should return the same instance
+    assertSame("HTTP clients should be the same for same account", client1, client2);
+  }
+
+  @Test
+  public void testHttpClientCachingWithDifferentAccounts() {
+    String accountName1 = "testaccount1";
+    String accountName2 = "testaccount2";
+
+    // Get HTTP clients for different accounts
+    CloseableHttpClient client1 = HttpUtil.getHttpClient(accountName1);
+    CloseableHttpClient client2 = HttpUtil.getHttpClient(accountName2);
+
+    // Should return different instances
+    assertNotSame("HTTP clients should be different for different accounts", client1, client2);
+  }
+
+  @Test
+  public void testHttpClientCachingWithSameProxySettings() {
+    String accountName = "testaccount";
+    Properties proxyProps = new Properties();
+    proxyProps.setProperty(SFSessionProperty.USE_PROXY.getPropertyKey(), "true");
+    proxyProps.setProperty(SFSessionProperty.PROXY_HOST.getPropertyKey(), "proxy.example.com");
+    proxyProps.setProperty(SFSessionProperty.PROXY_PORT.getPropertyKey(), "8080");
+
+    // Get HTTP client twice with same proxy settings
+    CloseableHttpClient client1 = HttpUtil.getHttpClient(accountName, proxyProps);
+    CloseableHttpClient client2 = HttpUtil.getHttpClient(accountName, proxyProps);
+
+    // Should return the same instance
+    assertSame("HTTP clients should be the same for same proxy settings", client1, client2);
+  }
+
+  @Test
+  public void testHttpClientCachingWithDifferentProxySettings() {
+    String accountName = "testaccount";
+
+    Properties proxyProps1 = new Properties();
+    proxyProps1.setProperty(SFSessionProperty.USE_PROXY.getPropertyKey(), "true");
+    proxyProps1.setProperty(SFSessionProperty.PROXY_HOST.getPropertyKey(), "proxy1.example.com");
+    proxyProps1.setProperty(SFSessionProperty.PROXY_PORT.getPropertyKey(), "8080");
+
+    Properties proxyProps2 = new Properties();
+    proxyProps2.setProperty(SFSessionProperty.USE_PROXY.getPropertyKey(), "true");
+    proxyProps2.setProperty(SFSessionProperty.PROXY_HOST.getPropertyKey(), "proxy2.example.com");
+    proxyProps2.setProperty(SFSessionProperty.PROXY_PORT.getPropertyKey(), "8080");
+
+    // Get HTTP clients with different proxy settings
+    CloseableHttpClient client1 = HttpUtil.getHttpClient(accountName, proxyProps1);
+    CloseableHttpClient client2 = HttpUtil.getHttpClient(accountName, proxyProps2);
+
+    // Should return different instances
+    assertNotSame("HTTP clients should be different for different proxy settings", client1, client2);
+  }
+
+  @Test
+  public void testHttpClientCachingWithProxyAndNoProxy() {
+    String accountName = "testaccount";
+
+    Properties proxyProps = new Properties();
+    proxyProps.setProperty(SFSessionProperty.USE_PROXY.getPropertyKey(), "true");
+    proxyProps.setProperty(SFSessionProperty.PROXY_HOST.getPropertyKey(), "proxy.example.com");
+    proxyProps.setProperty(SFSessionProperty.PROXY_PORT.getPropertyKey(), "8080");
+
+    // Get HTTP client with proxy and without proxy
+    CloseableHttpClient clientWithProxy = HttpUtil.getHttpClient(accountName, proxyProps);
+    CloseableHttpClient clientWithoutProxy = HttpUtil.getHttpClient(accountName);
+
+    // Should return different instances
+    assertNotSame("HTTP clients should be different for proxy vs no proxy", clientWithProxy, clientWithoutProxy);
+  }
+}

--- a/src/test/java/net/snowflake/ingest/utils/HttpUtilCacheTest.java
+++ b/src/test/java/net/snowflake/ingest/utils/HttpUtilCacheTest.java
@@ -1,6 +1,5 @@
 package net.snowflake.ingest.utils;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 
@@ -11,9 +10,9 @@ import org.junit.After;
 import org.junit.Test;
 
 /**
- * Test class for HttpUtil caching functionality.
- * Tests verify that HTTP clients are properly cached based on account name and proxy settings.
- * Note: Both JDBC and streaming clients now use unified SFSessionProperty constants for proxy configuration.
+ * Test class for HttpUtil caching functionality. Tests verify that HTTP clients are properly cached
+ * based on account name and proxy settings. Note: Both JDBC and streaming clients now use unified
+ * SFSessionProperty constants for proxy configuration.
  */
 public class HttpUtilCacheTest {
 
@@ -83,7 +82,8 @@ public class HttpUtilCacheTest {
     CloseableHttpClient client2 = HttpUtil.getHttpClient(accountName, proxyProps2);
 
     // Should return different instances
-    assertNotSame("HTTP clients should be different for different proxy settings", client1, client2);
+    assertNotSame(
+        "HTTP clients should be different for different proxy settings", client1, client2);
   }
 
   @Test
@@ -100,6 +100,9 @@ public class HttpUtilCacheTest {
     CloseableHttpClient clientWithoutProxy = HttpUtil.getHttpClient(accountName);
 
     // Should return different instances
-    assertNotSame("HTTP clients should be different for proxy vs no proxy", clientWithProxy, clientWithoutProxy);
+    assertNotSame(
+        "HTTP clients should be different for proxy vs no proxy",
+        clientWithProxy,
+        clientWithoutProxy);
   }
 }


### PR DESCRIPTION
Same as - https://github.com/confluentinc/snowflake-ingest-java/pull/35 with a little changes. Re-raised for review.

To be used with https://github.com/confluentinc/snowflake-kafka-connector/pull/109
Supports proxyProperties sent from connector and removes exclusive dependency on jvm level proxy params.

Modifies `SimpleIngestManager` for Snowpipe and SnowflakeStreamingIngestClientInternal for SnowpipeStreaming.

Adds caching to HttpClient so we don't create multiple clients for the same proxy server.

