### PR TITLE
Fix testInsertRowThrottling test

### DIFF
--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
@@ -726,7 +726,7 @@ public class SnowflakeStreamingIngestChannelTest {
 
   @Test
   public void testInsertRowThrottling() {
-    final long maxMemory = 1000000L;
+    final long maxMemory = 300000000L;
 
     final MockedMemoryInfoProvider memoryInfoProvider = new MockedMemoryInfoProvider();
     memoryInfoProvider.maxMemory = maxMemory;


### PR DESCRIPTION
If maxMemory is less than 200MB, connector will throttle indefinitely. Because we have added OR condition now it will check if freeMemory is less than 200MB it will set hasLowRuntimeMemory to True