### PR TITLE
Enable task buffer limit and dynamic flush

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/ChannelCache.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ChannelCache.java
@@ -195,11 +195,12 @@ class ChannelCache<T> {
     return cache.size();
   }
 
-  float getRowBufferSize() {
-    float total = 0;
-    for (ConcurrentHashMap<String, SnowflakeStreamingIngestChannelInternal<T>> channels : this.cache.values()) {
+  long getRowBufferSize() {
+    long total = 0;
+    for (ConcurrentHashMap<String, SnowflakeStreamingIngestChannelInternal<T>> channels :
+        this.cache.values()) {
       for (SnowflakeStreamingIngestChannelInternal<T> channel : channels.values()) {
-        total += channel.getRowBuffer().getSize();
+        total += (long) channel.getRowBuffer().getSize();
       }
     }
     return total;

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -287,9 +287,9 @@ class FlushService<T> {
               && (this.isNeedFlush || flushStartTime - this.lastFlushTime >= flushingInterval))) {
         tablesToFlush = this.channelCache.keySet();
         logger.logDebug(
-                "Channel cache (Total tables to flush) size={}, Total rowBufferSize={}",
-                this.channelCache.getSize(),
-                this.channelCache.getRowBufferSize());
+            "Channel cache (Total tables to flush) size={}, Total rowBufferSize={}",
+            this.channelCache.getSize(),
+            this.channelCache.getRowBufferSize());
       } else {
         tablesToFlush = null;
       }
@@ -360,13 +360,17 @@ class FlushService<T> {
 
     // Create thread for registering blobs
     ThreadFactory registerThreadFactory =
-        new ThreadFactoryBuilder().setNameFormat(threadNamePrefix + "ingest-register-thread").build();
+        new ThreadFactoryBuilder()
+            .setNameFormat(threadNamePrefix + "ingest-register-thread")
+            .build();
     this.registerWorker = Executors.newSingleThreadExecutor(registerThreadFactory);
 
     // Create threads for building and uploading blobs
     // Size: number of available processors * (1 + IO time/CPU time)
     ThreadFactory buildUploadThreadFactory =
-        new ThreadFactoryBuilder().setNameFormat(threadNamePrefix + "ingest-build-upload-thread-%d").build();
+        new ThreadFactoryBuilder()
+            .setNameFormat(threadNamePrefix + "ingest-build-upload-thread-%d")
+            .build();
     int buildUploadThreadCount =
         Math.min(
             Runtime.getRuntime().availableProcessors()

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
@@ -349,6 +349,7 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
       Iterable<Map<String, Object>> rows,
       @Nullable String startOffsetToken,
       @Nullable String endOffsetToken) {
+    triggerDynamicFlushIfNeeded();
     throttleInsertIfNeeded(memoryInfoProvider);
     checkValidation();
 
@@ -426,7 +427,8 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
     int retry = 0;
     while ((hasLowRuntimeMemory(memoryInfoProvider)
             || (this.owningClient.getFlushService() != null
-                && this.owningClient.getFlushService().throttleDueToQueuedFlushTasks()))
+                && this.owningClient.getFlushService().throttleDueToQueuedFlushTasks())
+            || exceedsTaskBufferLimit())
         && retry < INSERT_THROTTLE_MAX_RETRY_COUNT) {
       try {
         Thread.sleep(insertThrottleIntervalInMs);
@@ -484,5 +486,35 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
   @VisibleForTesting
   public ChannelFlushContext getChannelContext() {
     return channelFlushContext;
+  }
+
+  /** Check whether the total task buffer limit is exceeded by the channel cache */
+  private boolean exceedsTaskBufferLimit() {
+    if (!this.owningClient.getParameterProvider().isEnableDynamicFlush()) {
+      return false;
+    }
+    long currentBufferSize = this.owningClient.getChannelCache().getRowBufferSize();
+    long memoryLimitBytes = this.owningClient.getParameterProvider().getTaskBufferTotalLimitBytes();
+    boolean exceeds = currentBufferSize >= memoryLimitBytes;
+    if (exceeds) {
+      logger.logWarn(
+          "Task buffer limit exceeded, client={}, channel={}, "
+              + "currentBufferSize={}, taskBufferLimit={}",
+          this.owningClient.getName(),
+          getFullyQualifiedName(),
+          currentBufferSize,
+          memoryLimitBytes);
+    }
+    return exceeds;
+  }
+
+  /** Trigger dynamic flush if enabled and task buffer limit is exceeded by the channel cache. */
+  void triggerDynamicFlushIfNeeded() {
+    if (owningClient.getParameterProvider().isEnableDynamicFlush()
+        && this.exceedsTaskBufferLimit()) {
+      logger.logInfo(
+          "Triggering dynamic flushing due to channel exceeding total task buffer limit.");
+      this.owningClient.setNeedFlush(this.channelFlushContext.getFullyQualifiedTableName());
+    }
   }
 }

--- a/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
+++ b/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
@@ -51,6 +51,9 @@ public class ParameterProvider {
 
   public static final String TASK_ID = "TASK_ID".toLowerCase();
   public static final String CONNECTOR_NAME = "CONNECTOR_NAME".toLowerCase();
+  public static final String ENABLE_DYNAMIC_FLUSH = "ENABLE_DYNAMIC_FLUSH".toLowerCase();
+  public static final String TASK_BUFFER_TOTAL_LIMIT_BYTES =
+      "TASK_BUFFER_TOTAL_LIMIT_BYTES".toLowerCase();
 
   // Default values
   public static final long BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS_DEFAULT = 100;
@@ -67,6 +70,8 @@ public class ParameterProvider {
   public static final long MAX_CHUNK_SIZE_IN_BYTES_DEFAULT = 128 * 1024 * 1024;
   public static final String TASK_ID_DEFAULT = "-1";
   public static final String CONNECTOR_NAME_DEFAULT = "unknown";
+  public static final Boolean ENABLE_DYNAMIC_FLUSH_DEFAULT = false;
+  public static final long TASK_BUFFER_TOTAL_LIMIT_BYTES_DEFAULT = 524288000L; // 500 MB
 
   // Lag related parameters
   public static final long MAX_CLIENT_LAG_DEFAULT = 1000; // 1 second
@@ -276,12 +281,14 @@ public class ParameterProvider {
         false /* enforceDefault */);
 
     this.checkAndUpdate(
-        TASK_ID, TASK_ID_DEFAULT, parameterOverrides, props, false /* enforceDefault */
-    );
+        TASK_ID, TASK_ID_DEFAULT, parameterOverrides, props, false /* enforceDefault */);
 
     this.checkAndUpdate(
-        CONNECTOR_NAME, CONNECTOR_NAME_DEFAULT, parameterOverrides, props, false /* enforceDefault */
-    );
+        CONNECTOR_NAME,
+        CONNECTOR_NAME_DEFAULT,
+        parameterOverrides,
+        props,
+        false /* enforceDefault */);
 
     if (getMaxChunksInBlob() > getMaxChunksInRegistrationRequest()) {
       throw new IllegalArgumentException(
@@ -545,8 +552,23 @@ public class ParameterProvider {
   /** @return Ingest threads prefix */
   public String getThreadNamePrefix() {
     String taskId = (String) this.parameterMap.getOrDefault(TASK_ID, TASK_ID_DEFAULT);
-    String connectorName = (String) this.parameterMap.getOrDefault(CONNECTOR_NAME, CONNECTOR_NAME_DEFAULT);
+    String connectorName =
+        (String) this.parameterMap.getOrDefault(CONNECTOR_NAME, CONNECTOR_NAME_DEFAULT);
     return connectorName + "-" + taskId + "-";
+  }
+
+  /** @return Whether dynamic flushes is enabled */
+  public boolean isEnableDynamicFlush() {
+    Object val = this.parameterMap.getOrDefault(ENABLE_DYNAMIC_FLUSH, ENABLE_DYNAMIC_FLUSH_DEFAULT);
+    return (val instanceof String) ? Boolean.parseBoolean(val.toString()) : (boolean) val;
+  }
+
+  /** @return The task buffer total limit in bytes */
+  public long getTaskBufferTotalLimitBytes() {
+    Object val =
+        this.parameterMap.getOrDefault(
+            TASK_BUFFER_TOTAL_LIMIT_BYTES, TASK_BUFFER_TOTAL_LIMIT_BYTES_DEFAULT);
+    return (val instanceof String) ? Long.parseLong(val.toString()) : (long) val;
   }
 
   @Override

--- a/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
+++ b/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
@@ -290,6 +290,20 @@ public class ParameterProvider {
         props,
         false /* enforceDefault */);
 
+    this.checkAndUpdate(
+        ENABLE_DYNAMIC_FLUSH,
+        ENABLE_DYNAMIC_FLUSH_DEFAULT,
+        parameterOverrides,
+        props,
+        false /* enforceDefault */);
+
+    this.checkAndUpdate(
+        TASK_BUFFER_TOTAL_LIMIT_BYTES,
+        TASK_BUFFER_TOTAL_LIMIT_BYTES_DEFAULT,
+        parameterOverrides,
+        props,
+        false /* enforceDefault */);
+
     if (getMaxChunksInBlob() > getMaxChunksInRegistrationRequest()) {
       throw new IllegalArgumentException(
           String.format(

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ChannelCacheTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ChannelCacheTest.java
@@ -289,4 +289,14 @@ public class ChannelCacheTest {
         "Invalidated by test");
     Assert.assertFalse(channel3.isValid());
   }
+
+  @Test
+  public void testGetRowBufferSizeWithChannels() {
+    // The cache already has 3 channels from setup, all with empty buffers
+    // Initial size should be 0 since no rows have been inserted
+    long size = cache.getRowBufferSize();
+    Assert.assertEquals(0L, size);
+    // Verify the return type is long
+    Assert.assertTrue(size >= 0L);
+  }
 }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParameterProviderTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParameterProviderTest.java
@@ -458,4 +458,107 @@ public class ParameterProviderTest {
         TestUtils.createParameterProvider(parameterMap, prop, enableIcebergStreaming);
     Assert.assertFalse(parameterProvider.isEnableNewJsonParsingLogic());
   }
+
+  @Test
+  public void testEnableDynamicFlushDefaultValue() {
+    ParameterProvider parameterProvider = TestUtils.createParameterProvider(enableIcebergStreaming);
+    Assert.assertEquals(
+        ParameterProvider.ENABLE_DYNAMIC_FLUSH_DEFAULT, parameterProvider.isEnableDynamicFlush());
+    Assert.assertFalse(parameterProvider.isEnableDynamicFlush());
+  }
+
+  @Test
+  public void testEnableDynamicFlushSetToTrue() {
+    Properties prop = new Properties();
+    Map<String, Object> parameterMap = getStartingParameterMap();
+    parameterMap.put(ParameterProvider.ENABLE_DYNAMIC_FLUSH, true);
+    ParameterProvider parameterProvider =
+        TestUtils.createParameterProvider(parameterMap, prop, enableIcebergStreaming);
+    Assert.assertTrue(parameterProvider.isEnableDynamicFlush());
+  }
+
+  @Test
+  public void testEnableDynamicFlushSetToFalse() {
+    Properties prop = new Properties();
+    Map<String, Object> parameterMap = getStartingParameterMap();
+    parameterMap.put(ParameterProvider.ENABLE_DYNAMIC_FLUSH, false);
+    ParameterProvider parameterProvider =
+        TestUtils.createParameterProvider(parameterMap, prop, enableIcebergStreaming);
+    Assert.assertFalse(parameterProvider.isEnableDynamicFlush());
+  }
+
+  @Test
+  public void testEnableDynamicFlushAsString() {
+    Properties prop = new Properties();
+    Map<String, Object> parameterMap = getStartingParameterMap();
+    parameterMap.put(ParameterProvider.ENABLE_DYNAMIC_FLUSH, "true");
+    ParameterProvider parameterProvider =
+        TestUtils.createParameterProvider(parameterMap, prop, enableIcebergStreaming);
+    Assert.assertTrue(parameterProvider.isEnableDynamicFlush());
+  }
+
+  @Test
+  public void testTaskBufferTotalLimitBytesDefaultValue() {
+    ParameterProvider parameterProvider = TestUtils.createParameterProvider(enableIcebergStreaming);
+    Assert.assertEquals(
+        ParameterProvider.TASK_BUFFER_TOTAL_LIMIT_BYTES_DEFAULT,
+        parameterProvider.getTaskBufferTotalLimitBytes());
+    Assert.assertEquals(524288000L, parameterProvider.getTaskBufferTotalLimitBytes()); // 500 MB
+  }
+
+  @Test
+  public void testTaskBufferTotalLimitBytesCustomValue() {
+    Properties prop = new Properties();
+    Map<String, Object> parameterMap = getStartingParameterMap();
+    parameterMap.put(ParameterProvider.TASK_BUFFER_TOTAL_LIMIT_BYTES, 100000000L); // 100 MB
+    ParameterProvider parameterProvider =
+        TestUtils.createParameterProvider(parameterMap, prop, enableIcebergStreaming);
+    Assert.assertEquals(100000000L, parameterProvider.getTaskBufferTotalLimitBytes());
+  }
+
+  @Test
+  public void testTaskBufferTotalLimitBytesAsString() {
+    Properties prop = new Properties();
+    Map<String, Object> parameterMap = getStartingParameterMap();
+    parameterMap.put(ParameterProvider.TASK_BUFFER_TOTAL_LIMIT_BYTES, "200000000");
+    ParameterProvider parameterProvider =
+        TestUtils.createParameterProvider(parameterMap, prop, enableIcebergStreaming);
+    Assert.assertEquals(200000000L, parameterProvider.getTaskBufferTotalLimitBytes());
+  }
+
+  @Test
+  public void testTaskBufferTotalLimitBytesFromProperties() {
+    Properties prop = new Properties();
+    prop.put(ParameterProvider.TASK_BUFFER_TOTAL_LIMIT_BYTES, 300000000L);
+    ParameterProvider parameterProvider =
+        TestUtils.createParameterProvider(null, prop, enableIcebergStreaming);
+    Assert.assertEquals(300000000L, parameterProvider.getTaskBufferTotalLimitBytes());
+  }
+
+  @Test
+  public void testEnableDynamicFlushFromProperties() {
+    Properties prop = new Properties();
+    prop.put(ParameterProvider.ENABLE_DYNAMIC_FLUSH, true);
+    ParameterProvider parameterProvider =
+        TestUtils.createParameterProvider(null, prop, enableIcebergStreaming);
+    Assert.assertTrue(parameterProvider.isEnableDynamicFlush());
+  }
+
+  @Test
+  public void testDynamicFlushParametersOverrideProperties() {
+    Properties prop = new Properties();
+    prop.put(ParameterProvider.ENABLE_DYNAMIC_FLUSH, false);
+    prop.put(ParameterProvider.TASK_BUFFER_TOTAL_LIMIT_BYTES, 100000000L);
+
+    Map<String, Object> parameterMap = new HashMap<>();
+    parameterMap.put(ParameterProvider.ENABLE_DYNAMIC_FLUSH, true);
+    parameterMap.put(ParameterProvider.TASK_BUFFER_TOTAL_LIMIT_BYTES, 200000000L);
+
+    ParameterProvider parameterProvider =
+        TestUtils.createParameterProvider(parameterMap, prop, enableIcebergStreaming);
+
+    // Parameter overrides should take precedence over properties
+    Assert.assertTrue(parameterProvider.isEnableDynamicFlush());
+    Assert.assertEquals(200000000L, parameterProvider.getTaskBufferTotalLimitBytes());
+  }
 }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
@@ -970,4 +970,126 @@ public class SnowflakeStreamingIngestChannelTest {
       Assert.assertEquals(ErrorCode.CHANNEL_STATUS_INVALID.getMessageCode(), e.getVendorCode());
     }
   }
+
+  @Test
+  public void testThrottleInsertDueToTaskBufferLimitWhenDynamicFlushEnabled() throws Exception {
+    // Create a client with dynamic flush enabled and a small task buffer limit
+    Map<String, Object> parameterOverrides = new HashMap<>();
+    parameterOverrides.put(ParameterProvider.ENABLE_DYNAMIC_FLUSH, true);
+    parameterOverrides.put(ParameterProvider.TASK_BUFFER_TOTAL_LIMIT_BYTES, 100L); // Very small limit
+    parameterOverrides.put(ParameterProvider.INSERT_THROTTLE_INTERVAL_IN_MILLIS, 10L); // Short interval for testing
+
+    CloseableHttpClient httpClient = MockSnowflakeServiceClient.createHttpClient(apiOverride);
+    RequestBuilder requestBuilder =
+        MockSnowflakeServiceClient.createRequestBuilder(httpClient, enableIcebergStreaming);
+
+    try (SnowflakeStreamingIngestClientInternal<StubChunkData> clientWithDynamicFlush =
+        new SnowflakeStreamingIngestClientInternal<>(
+            "clientWithDynamicFlush",
+            null,
+            TestUtils.createProps(enableIcebergStreaming),
+            httpClient,
+            true,
+            requestBuilder,
+            parameterOverrides)) {
+
+      // Verify dynamic flush is enabled and task buffer limit is set
+      Assert.assertTrue(clientWithDynamicFlush.getParameterProvider().isEnableDynamicFlush());
+      Assert.assertEquals(100L, clientWithDynamicFlush.getParameterProvider().getTaskBufferTotalLimitBytes());
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testInsertRowThrottlingWithTaskBufferLimit() throws Exception {
+    final long maxMemory = 300000000L;
+
+    final MockedMemoryInfoProvider memoryInfoProvider = new MockedMemoryInfoProvider();
+    memoryInfoProvider.maxMemory = maxMemory;
+    memoryInfoProvider.freeMemory = maxMemory; // Enough free memory (no memory pressure)
+
+    // Create client with dynamic flush enabled and a small buffer limit
+    Map<String, Object> parameterOverrides = new HashMap<>();
+    parameterOverrides.put(ParameterProvider.ENABLE_DYNAMIC_FLUSH, true);
+    parameterOverrides.put(ParameterProvider.TASK_BUFFER_TOTAL_LIMIT_BYTES, 100L); // 100 byte limit
+    parameterOverrides.put(ParameterProvider.INSERT_THROTTLE_INTERVAL_IN_MILLIS, 50L); // Short interval for faster test
+
+    CloseableHttpClient httpClient = MockSnowflakeServiceClient.createHttpClient(apiOverride);
+    RequestBuilder requestBuilder =
+        MockSnowflakeServiceClient.createRequestBuilder(httpClient, enableIcebergStreaming);
+
+    try (SnowflakeStreamingIngestClientInternal<StubChunkData> clientWithSmallBuffer =
+        new SnowflakeStreamingIngestClientInternal<>(
+            "clientWithSmallBuffer",
+            null,
+            TestUtils.createProps(enableIcebergStreaming),
+            httpClient,
+            true,
+            requestBuilder,
+            parameterOverrides)) {
+
+      // Spy on the client to mock the channel cache's getRowBufferSize
+      SnowflakeStreamingIngestClientInternal<StubChunkData> spyClient =
+          Mockito.spy(clientWithSmallBuffer);
+      ChannelCache<StubChunkData> mockCache = Mockito.mock(ChannelCache.class);
+
+      // Track the number of calls to simulate buffer draining after a few retries
+      final int[] callCount = {0};
+      final int callsBeforeBufferDrains = 3; // After 3 calls, buffer "drains" below limit
+
+      Mockito.when(mockCache.getRowBufferSize()).thenAnswer(invocation -> {
+        callCount[0]++;
+        if (callCount[0] <= callsBeforeBufferDrains) {
+          // First few calls: buffer exceeds limit (1000 > 100), throttle should continue
+          return 1000L;
+        } else {
+          // After a few retries: buffer is below limit (0 < 100), throttle should stop
+          return 0L;
+        }
+      });
+      Mockito.when(spyClient.getChannelCache()).thenReturn(mockCache);
+
+      SnowflakeStreamingIngestChannelInternal<StubChunkData> channel =
+          new SnowflakeStreamingIngestChannelInternal<>(
+              "channel",
+              "db",
+              "schema",
+              "table",
+              "0",
+              0L,
+              0L,
+              spyClient,
+              "key",
+              1234L,
+              OpenChannelRequest.OnErrorOption.CONTINUE,
+              UTC,
+              null /* offsetTokenVerificationFunction */,
+              enableIcebergStreaming
+                  ? ParquetProperties.WriterVersion.PARQUET_2_0
+                  : ParquetProperties.WriterVersion.PARQUET_1_0);
+
+      // Verify the mock setup
+      Assert.assertEquals(100L, spyClient.getParameterProvider().getTaskBufferTotalLimitBytes());
+      Assert.assertTrue(spyClient.getParameterProvider().isEnableDynamicFlush());
+
+      // Record start time
+      long startTime = System.currentTimeMillis();
+
+      // Run throttle - it should block initially then release after buffer "drains"
+      channel.throttleInsertIfNeeded(memoryInfoProvider);
+
+      long elapsedTime = System.currentTimeMillis() - startTime;
+
+      // Verify that throttle was triggered (took at least some time due to retries)
+      // With 50ms interval and ~3 retries before buffer drains, should take ~150ms
+      Assert.assertTrue(
+          "Throttle should have blocked for at least 100ms due to buffer limit, but took " + elapsedTime + "ms",
+          elapsedTime >= 100L);
+
+      // Verify the mock was called multiple times (throttle retried)
+      Assert.assertTrue(
+          "getRowBufferSize should have been called multiple times during throttle, called " + callCount[0] + " times",
+          callCount[0] > callsBeforeBufferDrains);
+    }
+  }
 }


### PR DESCRIPTION
Add implementation to trigger dynamic flush and throttle on task buffer limit bytes.